### PR TITLE
Used jinja filters to fix pagination losing context on page change

### DIFF
--- a/quorem/jinja/filters.py
+++ b/quorem/jinja/filters.py
@@ -1,5 +1,6 @@
 import re
 from jinja2 import Markup
+from jinja2 import contextfilter
 from django.utils.http import urlencode
 from django.shortcuts import render
 
@@ -16,6 +17,7 @@ def highlight(text, selection):
         text = text.replace(i, "<mark>{0}</mark>".format(i))
     return Markup(text)
 
+@contextfilter
 def add_type(context, type_name):
     q_dict = context.copy()
     q_dict['selected']['type'] = type_name
@@ -38,3 +40,10 @@ def format_pages(paginator, current_page, neighbors=5):
         page_list = [f for f in range(start_index, end_index+1)]
         return page_list[:(2*neighbors + 1)]
     return paginator.page_range
+
+#Generate pagination links that don't discard the search filters.
+@contextfilter
+def page_url(context, page_num):
+    ctx = context['request'].GET.copy()
+    ctx['page'] = str(page_num)
+    return '?' + ctx.urlencode()

--- a/quorem/jinja2.py
+++ b/quorem/jinja2.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 
 from jinja2 import Environment
 from jinja2.runtime import Context
-from .jinja.filters import highlight, add_type, format_pages
+from .jinja.filters import highlight, add_type, format_pages, page_url
 
 def environment(**options):
     env = Environment(**options)
@@ -15,5 +15,6 @@ def environment(**options):
         'highlight' : highlight,
         'add_type': add_type,
         'format_pages':format_pages,
+        'page_url': page_url,
     })
     return env

--- a/quorem/jinja2/_pagination.htm
+++ b/quorem/jinja2/_pagination.htm
@@ -1,38 +1,12 @@
-{#
-{% if page.paginator.num_pages > 1 %}
-        <ul class="pagination">
-            {% if page.has_previous() %}
-              <li class="page-item"><a class="page-link text-info" href="?q={{ q }}&page={{ page.previous_page_number() }}">&laquo;</a></li>
-            {% else %}
-              <li class="page-item diasbled"><a class="page-link text-info">&laquo;</a></li>
-            {% endif %}
-
-            {% for i in page.paginator.page_range %}
-              {% if page.number == i %}
-              <li class="page-item active bg-info"><a class="page-link bg-info" href="#">{{ i }}</a></li>
-              {% else %}
-              <li class="page-item"><a class="page-link text-info" href="?q={{ q }}&page={{ i }}">{{ i }}</a></li>
-              {% endif %}
-            {% endfor %}
-            {% if page.has_next() %}
-                <li class="page-item"><a class="page-link text-info" href="?q={{ q }}&page={{ page.paginator.num_pages }}">&raquo;</a></li>
-            {% else %}
-              <li class="page-item disabled"><a class="page-link">&raquo;</a></li>
-            {% endif %}
-        </ul>
-  {% endif}
-{% endif %}
-#}
-
 {% if page.paginator.num_pages > 1 %}
   <ul class="pagination">
     {% if page.number == 1 %}
       <li class="page-item disabled"><a class="page-link text-info">First</a></li>
     {% else %}
-      <li class="page-item"><a class="page-link text-info" href="?q={{ q }}&page=1">First</a></li>
+      <li class="page-item"><a class="page-link text-info" href="{{ 1|page_url() }}">First</a></li>
     {% endif %}
     {% if page.has_previous() %}
-      <li class="page-item"><a class="page-link text-info" href="?q={{ q }}&page={{ page.previous_page_number() }}">&laquo;</a></li>
+      <li class="page-item"><a class="page-link text-info" href="{{ (page.number-1)|page_url() }}">&laquo;</a></li>
     {% else %}
       <li class="page-item diasbled"><a class="page-link text-info">&laquo;</a></li>
     {% endif %}
@@ -40,18 +14,18 @@
       {% if page.number == i %}
         <li class="page-item active bg-info"><a class="page-link bg-info" href="#">{{ i }}</a></li>
       {% else %}
-        <li class="page-item"><a class="page-link text-info" href="?q={{ q }}&page={{ i }}">{{ i }}</a></li>
+        <li class="page-item"><a class="page-link text-info" href="{{ i|page_url() }}">{{ i }}</a></li>
       {% endif %}
     {% endfor %}
     {% if page.has_next() %}
-        <li class="page-item"><a class="page-link text-info" href="?q={{ q }}&page={{ page.number + 1 }}">&raquo;</a></li>
+        <li class="page-item"><a class="page-link text-info" href="{{ (page.number + 1)|page_url() }}">&raquo;</a></li>
     {% else %}
       <li class="page-item disabled"><a class="page-link">&raquo;</a></li>
     {% endif %}
     {% if page.number == page.paginator.num_pages %}
       <li class="page-item disabled"><a class="page-link text-info">Last</a></li>
     {% else %}
-      <li class="page-item"><a class="page-link text-info" href="?q={{ q }}&page={{ page.paginator.num_pages }}">last</a></li>
+      <li class="page-item"><a class="page-link text-info" href="{{ page.paginator.num_pages|page_url() }}">last</a></li>
     {% endif %}
   </ul>
 {% endif %}


### PR DESCRIPTION
What it says on the tin.
Previously, hardcoded urls created an error in which changing the current page from paginated search results lost all the search filters.
Now, Jinja filters dynamically create urls for search result pagination, preventing loss of context from page navigation. 
Search results should now behave as expected.