### PR TITLE
Value Table Form Improvements

### DIFF
--- a/db/forms.py
+++ b/db/forms.py
@@ -471,6 +471,7 @@ class TrendPlotForm(forms.Form):
 class ValueTableForm(forms.Form):
     #need a field for choosing a dependant variable
     CHOICES = [
+                ('', "Select..."),
                 ('1', 'Investigation'),
                 ('2', 'Sample'),
                 ('3', 'Feature'),

--- a/db/static/js/aggregation_form.js
+++ b/db/static/js/aggregation_form.js
@@ -249,7 +249,6 @@ function populateYFieldNames(){
     },
     success: function(data){
       console.log('success populate y names');
-      console.log(data);
       $('#id_indField_0').html(data);
     }
   });
@@ -261,11 +260,12 @@ function populateAdditionalFieldNames(e, n){
   console.log('sanity');
   console.log(e);
   var previousSelect = '#id_indField_' + n;
-  var options = document.querySelector(previousSelect).options
+  var options = document.querySelector(previousSelect).options;
   var selected = $( previousSelect ).val();
   var optcop = $( options ).clone();
+  $(e).empty();
   for (var i = 0; i < optcop.length; i++){
-    if ($(optcop[i]).val() != selected){
+    if ($(optcop[i]).val() != selected && $(optcop[i]).val() != ""){
       e.options.add(optcop[i],);
     }
   }
@@ -283,14 +283,22 @@ function populateYValNames(e){
       'object_klass': object_klass,
     },
     success: function(data){
-      console.log("Success populate y val");
       $( valId ).html(data);
       $( valId ).trigger('chosen:updated');
       $( valId ).chosen();
     }
   });
 }
-
+//when you select on object, change what's available downstream
+function updateDownstreamFields(e){
+  console.log('blep');
+  var indFields = $('*[id^="id_indField"]');
+  var n = parseInt(this.id.split("_")[2]);
+  for (var i = n+1; i < indFields.length; i++){
+    populateAdditionalFieldNames(indFields[i], i-1);
+    populateYValNames(indFields[i]);
+  }
+}
 
 
 $("#id_depField").change(populateXValNames);
@@ -310,10 +318,12 @@ $(document).ready(function(){
   $('#id_indValue').attr("id", "id_indValue_0");
 
   $('#id_indField_0').change(populateYValNames);
+  $('#id_indField_0').change(updateDownstreamFields);
+
 
   $(".add-fields").click(function(){
     var n_opts = document.getElementById('id_indField_0').options.length;
-    if (n_opts > $n){
+    if (n_opts -1 > $n ){
       var $clone = $( "div.form-fields" ).first().clone();
       $clone.find('#id_indValue_0_chosen').remove().end();
       $clone.find('option').remove().end();
@@ -337,6 +347,7 @@ $(document).ready(function(){
 
 
       $('#' + $fieldId).change(populateYValNames);
+      $('#' + $fieldId).change(updateDownstreamFields);
       $('#' + $fieldId).val('').end();
 
     //  $('#' + $valId).trigger('chosen:updated');

--- a/db/static/js/aggregation_form.js
+++ b/db/static/js/aggregation_form.js
@@ -296,7 +296,7 @@ function updateDownstreamFields(e){
   var n = parseInt(this.id.split("_")[2]);
   for (var i = n+1; i < indFields.length; i++){
     populateAdditionalFieldNames(indFields[i], i-1);
-    populateYValNames(indFields[i]);
+  //  populateYValNames(indFields[i]);
   }
 }
 

--- a/db/views.py
+++ b/db/views.py
@@ -1098,7 +1098,7 @@ def ajax_value_table_related_models_view(request):
     # Current logic prevents using more than just the names, so use them for now.
     klasses = list(linked_objects.keys())
     klass_list = [reverse_klass_map[k] for k in klasses]
-
+    klass_list.insert(0, ('', "Select..."))
     #pass the class list to html snippet, which will be used to populate form
     return render(request, 'search/ajax_value_names_y.htm', {'options': klass_list})
 

--- a/quorem/jinja2/search/ajax_value_names.htm
+++ b/quorem/jinja2/search/ajax_value_names.htm
@@ -1,3 +1,4 @@
+<option value="">Select one or more..</option>
 {% for value_name in qs %}
 <option value="{{ value_name }}">{{ value_name }}</option>
 {% endfor %}

--- a/quorem/jinja2/search/ajax_value_names.htm
+++ b/quorem/jinja2/search/ajax_value_names.htm
@@ -1,4 +1,3 @@
-<option value="">Select one or more..</option>
 {% for value_name in qs %}
 <option value="{{ value_name }}">{{ value_name }}</option>
 {% endfor %}


### PR DESCRIPTION
Value table form now works much better.

- Form fields start focused on a "null" entry. This makes the user select their first model choice, triggering selection JS

- When selecting independent variables for value table, a user can no longer select the same model twice. The "select more" button only works if there are additional models which are possible to connect to the existing selections.

- The form prevents redundancy dynamically. This is best explained with an example:
    * The user selects Step as the dependant variable, with some value that allows both Step and Process on the next page.
    * The user has a drop down for "Step, Process". They choose Step, then click "select more"
    * A new field is generated. The only option is Process. clicking select more at this point does nothing.
    * The user changes their first selection from Step to Process. The second Field is cleared and repopulated. Now, the only choice in the second field is Step.
